### PR TITLE
Fix transaction sign handling with debit_as_negative flag

### DIFF
--- a/lambda/processor/processor.py
+++ b/lambda/processor/processor.py
@@ -271,7 +271,7 @@ def sync_to_lunchmoney(api_key, transaction):
             "Content-Type": "application/json",
         }
 
-        payload = {"transactions": [transaction]}
+        payload = {"transactions": [transaction], "debit_as_negative": True}
 
         logger.debug(f"Transaction to Sync: {transaction}")
         response = requests.post(


### PR DESCRIPTION
Add debit_as_negative flag to LunchMoney API payload to correctly
handle transaction signs. Up Bank uses negative values for expenses
and positive for income, which matches LunchMoney's debit_as_negative
convention.

Fixes #42
