### PR TITLE
Add batch window configuration to SQS event source

### DIFF
--- a/up_bank_lunch_money_sync/up_bank_lunch_money_sync_stack.py
+++ b/up_bank_lunch_money_sync/up_bank_lunch_money_sync_stack.py
@@ -242,7 +242,9 @@ class UpBankLunchMoneySyncStack(Stack):
         )
 
         # Set up SQS trigger for processor
-        sqs_event_source = SqsEventSource(queue, batch_size=10)
+        sqs_event_source = SqsEventSource(
+            queue, batch_size=10, max_batching_window=Duration.seconds(30)
+        )
         processor_lambda.add_event_source(sqs_event_source)
 
         # Create EventBridge rule to run account sync daily at 2 AM UTC


### PR DESCRIPTION
- Added max_batching_window=Duration.seconds(30) to SqsEventSource
- Lambda will now wait up to 30 seconds to collect messages
- Reduces Lambda invocations for low-traffic scenarios
- Improves cost efficiency

Fixes #8
