### PR TITLE
fix: reduce processor Lambda timeout and adjust SQS visibility timeout

### DIFF
--- a/tests/unit/test_up_bank_lunch_money_sync_stack.py
+++ b/tests/unit/test_up_bank_lunch_money_sync_stack.py
@@ -1,3 +1,5 @@
+import os
+
 import aws_cdk as core
 import aws_cdk.assertions as assertions
 
@@ -6,10 +8,16 @@ from up_bank_lunch_money_sync.up_bank_lunch_money_sync_stack import UpBankLunchM
 # example tests. To run these tests, uncomment this file along with the example
 # resource in up_bank_lunch_money_sync/up_bank_lunch_money_sync_stack.py
 def test_sqs_queue_created():
+    # Set valid ARNs for testing
+    os.environ["WEBHOOK_SECRET_ARN"] = "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-webhook-abcdef"
+    os.environ["UP_API_KEY_ARN"] = "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-up-api-abcdef"
+    os.environ["LUNCHMONEY_API_KEY_ARN"] = "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-lunchmoney-abcdef"
+    
     app = core.App()
     stack = UpBankLunchMoneySyncStack(app, "up-bank-lunch-money-sync")
     template = assertions.Template.from_stack(stack)
 
-#     template.has_resource_properties("AWS::SQS::Queue", {
-#         "VisibilityTimeout": 300
-#     })
+    # Test SQS queue has correct visibility timeout (12 minutes = 720 seconds)
+    template.has_resource_properties("AWS::SQS::Queue", {
+        "VisibilityTimeout": 720
+    })

--- a/up_bank_lunch_money_sync/up_bank_lunch_money_sync_stack.py
+++ b/up_bank_lunch_money_sync/up_bank_lunch_money_sync_stack.py
@@ -94,10 +94,11 @@ class UpBankLunchMoneySyncStack(Stack):
         )
 
         # Create SQS queue for transaction processing with DLQ
+        # Visibility timeout is 6x processor Lambda timeout (2 min * 6 = 12 min)
         queue = sqs.Queue(
             self,
             "UpWebhookQueue",
-            visibility_timeout=Duration.seconds(300),
+            visibility_timeout=Duration.seconds(720),
             retention_period=Duration.days(14),
             dead_letter_queue=sqs.DeadLetterQueue(
                 max_receive_count=5,
@@ -169,7 +170,7 @@ class UpBankLunchMoneySyncStack(Stack):
                 "ACCOUNT_MAPPING_TABLE": account_mapping_table.table_name,
                 "CATEGORY_MAPPING_TABLE": category_mapping_table.table_name,
             },
-            timeout=Duration.minutes(5),
+            timeout=Duration.minutes(2),
         )
 
         # Account Sync Lambda function
@@ -271,7 +272,7 @@ class UpBankLunchMoneySyncStack(Stack):
                 webhook_lambda, "Webhook", notification_topic, Duration.seconds(24)
             )
             self._create_lambda_alarms(
-                processor_lambda, "Processor", notification_topic, Duration.minutes(4)
+                processor_lambda, "Processor", notification_topic, Duration.seconds(96)
             )
             self._create_lambda_alarms(
                 account_sync_lambda,


### PR DESCRIPTION
- Reduce processor Lambda timeout from 5 minutes to 2 minutes
- Adjust SQS visibility timeout to 12 minutes (6x Lambda timeout)
- Update CloudWatch alarm threshold to 96 seconds (80% of new timeout)
- Fix and update stack tests with proper secret ARNs

Fixes #10
